### PR TITLE
Specify root directory path for FileReceiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ In addition, the fileReceiver servlet needs to be registered in web.xml.
   <servlet>
     <servlet-name>fileReceiver</servlet-name>
     <servlet-class>org.nlp4l.solr.servlet.FileReceiver</servlet-class>
+    <init-param>
+      <param-name>root_path</param-name>
+      <param-value>/path/to/solr_core</param-value>
+    </init-param>
   </servlet>
 
   <servlet-mapping>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.nlp4l.solr</groupId>
   <artifactId>nlp4l-solr</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>nlp4l-solr</name>

--- a/src/main/java/org/nlp4l/solr/servlet/FileReceiver.java
+++ b/src/main/java/org/nlp4l/solr/servlet/FileReceiver.java
@@ -16,6 +16,7 @@
 
 package org.nlp4l.solr.servlet;
 
+import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServlet;
@@ -27,6 +28,19 @@ import java.io.IOException;
 
 public class FileReceiver extends HttpServlet {
 
+  private static final String ROOT_PATH_PARAM = "root_path";
+  private String rootPath = null;
+
+  @Override
+  public void init() throws ServletException {
+    super.init();
+    ServletConfig config = getServletConfig();
+    String rootPath = config.getInitParameter(ROOT_PATH_PARAM);
+    if (rootPath != null && !rootPath.equals("")) {
+      this.rootPath = rootPath;
+    }
+  }
+
   @Override
   public void doPut(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
     String file = req.getParameter("file");
@@ -34,7 +48,12 @@ public class FileReceiver extends HttpServlet {
       res.sendError(HttpServletResponse.SC_BAD_REQUEST, "file parameter is not specified");
       return;
     }
-    File f = new File(file).getAbsoluteFile();
+    if (rootPath == null) {
+      res.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "root path is not specified in server configuration");
+      return;
+    }
+
+    File f = new File(rootPath, file).getAbsoluteFile();
     File parent = f.getParentFile();
     if(!parent.exists()){
       System.out.printf("*** directory '%s' doesn't exist\n", parent);


### PR DESCRIPTION
An user can override arbitrary file via FileReceiver servlet. It's too danger if Solr is running as root user.
This patch makes server administrators can specify the root path for FileReceiver, and users are allowed to  put files to under the directory.
